### PR TITLE
Rooms type

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -22,6 +22,6 @@ export interface Room {
   name: string;
 }
 
-export interface CreateRoomRequest {
+export interface c {
   name: string;
 }

--- a/common/types.ts
+++ b/common/types.ts
@@ -19,5 +19,9 @@ along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 
 export interface Room {
   id: number;
-  name: number;
+  name: string;
+}
+
+export interface CreateRoomRequest {
+  name: string;
 }

--- a/common/types.ts
+++ b/common/types.ts
@@ -22,6 +22,6 @@ export interface Room {
   name: string;
 }
 
-export interface c {
+export interface CreateRoomRequest{
   name: string;
 }


### PR DESCRIPTION
This PR adds a `CreateRoomRequest` type to the common types folder. This type is for use when creating a Room before it has an ID.