### PR TITLE
Operation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,7 +61,6 @@ module.exports = {
         selector: 'memberLike'
       }
     ],
-    '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/prefer-function-type': 'error',
     'import/order': [
       'error',

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,41 +18,41 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "@material-ui/core": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.1.tgz",
-      "integrity": "sha512-aesI8lOaaw0DRIfNG+Anepf61NH5Q+cmkxJOZvI1oHkmD5cKubkZ0C7INqFKjfFpSFlFnqHkTasoM7ogFAvzOg==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.2.tgz",
+      "integrity": "sha512-/D1+AQQeYX/WhT/FUk78UCRj8ch/RCglsQLYujYTIqPSJlwZHKcvHidNeVhODXeApojeXjkl0tWdk5C9ofwOkQ==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/styles": "^4.11.1",
-        "@material-ui/system": "^4.9.14",
+        "@material-ui/styles": "^4.11.2",
+        "@material-ui/system": "^4.11.2",
         "@material-ui/types": "^5.1.0",
-        "@material-ui/utils": "^4.10.2",
+        "@material-ui/utils": "^4.11.2",
         "@types/react-transition-group": "^4.2.0",
         "clsx": "^1.0.4",
         "hoist-non-react-statics": "^3.3.2",
         "popper.js": "1.16.1-lts",
         "prop-types": "^15.7.2",
-        "react-is": "^16.8.0",
+        "react-is": "^16.8.0 || ^17.0.0",
         "react-transition-group": "^4.4.0"
       }
     },
     "@material-ui/icons": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.9.1.tgz",
-      "integrity": "sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.11.2.tgz",
+      "integrity": "sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==",
       "requires": {
         "@babel/runtime": "^7.4.4"
       }
     },
     "@material-ui/styles": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.1.tgz",
-      "integrity": "sha512-GqzsFsVWT8jXa8OWAd1WD6WIaqtXr2mUPbRZ1EjkiM3Dlta4mCRaToDxkFVv6ZHfXlFjMJzdaIEvCpZOCvZTvg==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.2.tgz",
+      "integrity": "sha512-xbItf8zkfD3FuGoD9f2vlcyPf9jTEtj9YTJoNNV+NMWaSAHXgrW6geqRoo/IwBuMjqpwqsZhct13e2nUyU9Ljw==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@emotion/hash": "^0.8.0",
         "@material-ui/types": "^5.1.0",
-        "@material-ui/utils": "^4.9.6",
+        "@material-ui/utils": "^4.11.2",
         "clsx": "^1.0.4",
         "csstype": "^2.5.2",
         "hoist-non-react-statics": "^3.3.2",
@@ -68,12 +68,12 @@
       }
     },
     "@material-ui/system": {
-      "version": "4.9.14",
-      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.9.14.tgz",
-      "integrity": "sha512-oQbaqfSnNlEkXEziDcJDDIy8pbvwUmZXWNqlmIwDqr/ZdCK8FuV3f4nxikUh7hvClKV2gnQ9djh5CZFTHkZj3w==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.11.2.tgz",
+      "integrity": "sha512-BELFJEel5E+5DMiZb6XXT3peWRn6UixRvBtKwSxqntmD0+zwbbfCij6jtGwwdJhN1qX/aXrKu10zX31GBaeR7A==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.9.6",
+        "@material-ui/utils": "^4.11.2",
         "csstype": "^2.5.2",
         "prop-types": "^15.7.2"
       }
@@ -84,19 +84,25 @@
       "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
     },
     "@material-ui/utils": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.10.2.tgz",
-      "integrity": "sha512-eg29v74P7W5r6a4tWWDAAfZldXIzfyO1am2fIsC39hdUUHm/33k6pGOKPbgDjg/U/4ifmgAePy/1OjkKN6rFRw==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
+      "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "prop-types": "^15.7.2",
-        "react-is": "^16.8.0"
+        "react-is": "^16.8.0 || ^17.0.0"
       }
     },
+    "@types/debounce": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/debounce/-/debounce-1.2.0.tgz",
+      "integrity": "sha512-bWG5wapaWgbss9E238T0R6bfo5Fh3OkeoSt245CM7JJwVwpw6MEBCbIxLq5z8KzsE3uJhzcIuQkyiZmzV3M/Dw==",
+      "dev": true
+    },
     "@types/eslint": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.5.tgz",
-      "integrity": "sha512-Dc6ar9x16BdaR3NSxSF7T4IjL9gxxViJq8RmFd+2UAyA+K6ck2W+gUwfgpG/y9TPyUuBL35109bbULpEynvltA==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.6.tgz",
+      "integrity": "sha512-I+1sYH+NPQ3/tVqCeUSBwTE/0heyvtXqpIopUUArlBm0Kpocb8FbMa3AZ/ASKIFpN3rnEx932TTXDbt9OXsNDw==",
       "dev": true,
       "requires": {
         "@types/estree": "*",
@@ -126,9 +132,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.9.tgz",
-      "integrity": "sha512-JsoLXFppG62tWTklIoO4knA+oDTYsmqWxHRvd4lpmfQRNhX6osheUOWETP2jMoV/2bEHuMra8Pp3Dmo/stBFcw==",
+      "version": "14.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
+      "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==",
       "dev": true
     },
     "@types/prop-types": {
@@ -432,16 +438,16 @@
       }
     },
     "browserslist": {
-      "version": "4.14.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.7.tgz",
-      "integrity": "sha512-BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.15.0.tgz",
+      "integrity": "sha512-IJ1iysdMkGmjjYeRlDU8PQejVwxvVO5QOfXH7ylW31GO6LwNRSmm/SgRXtNsEXqMLl2e+2H5eEJ7sfynF8TCaQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001157",
+        "caniuse-lite": "^1.0.30001164",
         "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.591",
+        "electron-to-chromium": "^1.3.612",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.66"
+        "node-releases": "^1.1.67"
       }
     },
     "buffer-from": {
@@ -451,9 +457,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001161",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001161.tgz",
-      "integrity": "sha512-JharrCDxOqPLBULF9/SPa6yMcBRTjZARJ6sc3cuKrPfyIk64JN6kuMINWqA99Xc8uElMFcROliwtz0n9pYej+g==",
+      "version": "1.0.30001165",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001165.tgz",
+      "integrity": "sha512-8cEsSMwXfx7lWSUMA2s08z9dIgsnR5NAqjXP23stdsU3AUWkCr/rr4s4OFtHXn5XXr6+7kam3QFVoYyXNPdJPA==",
       "dev": true
     },
     "chalk": {
@@ -556,6 +562,11 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
       "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
     },
+    "debounce": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
+      "integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg=="
+    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -579,9 +590,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.606",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.606.tgz",
-      "integrity": "sha512-+/2yPHwtNf6NWKpaYt0KoqdSZ6Qddt6nDfH/pnhcrHq9hSb23e5LFy06Mlf0vF2ykXvj7avJ597psqcbKnG5YQ==",
+      "version": "1.3.616",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.616.tgz",
+      "integrity": "sha512-CI8L38UN2BEnqXw3/oRIQTmde0LiSeqWSRlPA42ZTYgJQ8fYenzAM2Z3ni+jtILTcrs5aiXZCGJ96Pm+3/yGyQ==",
       "dev": true
     },
     "emojis-list": {
@@ -1346,9 +1357,9 @@
       }
     },
     "reduxology": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/reduxology/-/reduxology-2.0.0.tgz",
-      "integrity": "sha512-CzHKvkAvIeO3r0vqSTFPOu6fefGSpfOj3Wt+ezTGQUn1/XTvPlB7FgX/Z8vYkFgl3V9RHYfWPN6wKenRGMtmYQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/reduxology/-/reduxology-2.1.0.tgz",
+      "integrity": "sha512-6neltQOGMyOYpQKHLNkAvFeZON0iyn7hH8zHpRMRxFCYRAUw8vRxtR5gIu9e41Fb23ISNfN2kNgddx884eHf6A==",
       "requires": {
         "immer": "^8.0.0",
         "react-redux": "^7.2.2",
@@ -1517,9 +1528,9 @@
       "dev": true
     },
     "terser": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.5.0.tgz",
-      "integrity": "sha512-eopt1Gf7/AQyPhpygdKePTzaet31TvQxXvrf7xYUvD/d8qkCJm4SKPDzu+GHK5ZaYTn8rvttfqaZc3swK21e5g==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.5.1.tgz",
+      "integrity": "sha512-6VGWZNVP2KTUcltUQJ25TtNjx/XgdDsBDKGt8nN0MpydU36LmbPPcMBd2kmtZNNGVVDLg44k7GKeHHj+4zPIBQ==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -1550,12 +1561,12 @@
       },
       "dependencies": {
         "p-limit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
-          "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "yocto-queue": "^0.1.0"
           }
         }
       }
@@ -1637,9 +1648,9 @@
       }
     },
     "webpack": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.6.0.tgz",
-      "integrity": "sha512-SIeFuBhuheKElRbd84O35UhKc0nxlgSwtzm2ksZ0BVhRJqxVJxEguT/pYhfiR0le/pxTa1VsCp7EOYyTsa6XOA==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.10.0.tgz",
+      "integrity": "sha512-P0bHAXmIz0zsNcHNLqFmLY1ZtrT+jtBr7FqpuDtA2o7GiHC+zBsfhgK7SmJ1HG7BAEb3G9JoMdSVi7mEDvG3Zg==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",
@@ -1660,28 +1671,74 @@
         "loader-runner": "^4.1.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "pkg-dir": "^4.2.0",
+        "pkg-dir": "^5.0.0",
         "schema-utils": "^3.0.0",
-        "tapable": "^2.0.0",
+        "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.0.3",
         "watchpack": "^2.0.0",
         "webpack-sources": "^2.1.1"
       },
       "dependencies": {
         "enhanced-resolve": {
-          "version": "5.3.2",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.3.2.tgz",
-          "integrity": "sha512-G28GCrglCAH6+EqMN2D+Q2wCUS1O1vVQJBn8ME2I/Api41YBe4vLWWRBOUbwDH7vwzSZdljxwTRVqnf+sm6XqQ==",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.4.0.tgz",
+          "integrity": "sha512-ZmqfWURB2lConOBM1JdCVfPyMRv5RdKWktLXO6123p97ovVm2CLBgw9t5MBj3jJWA6eHyOeIws9iJQoGFR4euQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.4",
             "tapable": "^2.0.0"
           }
         },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "pkg-dir": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^5.0.0"
+          }
+        },
         "tapable": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.1.1.tgz",
-          "integrity": "sha512-Wib1S8m2wdpLbmQz0RBEVosIyvb/ykfKXf3ZIDqvWoMg/zTNm6G/tDSuUM61J1kNCDXWJrLHGSFeMhAG+gAGpQ==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
+          "integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==",
           "dev": true
         }
       }
@@ -1757,6 +1814,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
     }
   }

--- a/client/package.json
+++ b/client/package.json
@@ -11,19 +11,21 @@
   "author": "Bryan Hughes <bryan@nebri.us>",
   "license": "GPL-3.0",
   "devDependencies": {
+    "@types/debounce": "^1.2.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "ts-loader": "^8.0.11",
     "typescript": "^4.1.2",
-    "webpack": "^5.6.0",
+    "webpack": "^5.10.0",
     "webpack-cli": "^4.2.0"
   },
   "dependencies": {
-    "@material-ui/core": "^4.11.1",
-    "@material-ui/icons": "^4.9.1",
+    "@material-ui/core": "^4.11.2",
+    "@material-ui/icons": "^4.11.2",
     "conditional-reduce": "^1.2.0",
+    "debounce": "^1.2.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "reduxology": "^2.0.0"
+    "reduxology": "^2.1.0"
   }
 }

--- a/client/src/components/light/lightComponent.tsx
+++ b/client/src/components/light/lightComponent.tsx
@@ -25,6 +25,7 @@ import {
   LightType,
   Zone
 } from '../../common/types';
+import { getItem } from '../../common/util';
 import { EditLightButtonContainer } from '../../containers/editLightButtonContainer';
 import { useContentStyles } from '../lib/pageStyles';
 import {
@@ -51,7 +52,10 @@ export const LightComponent: FunctionComponent<
   const classes = styles();
   const contentClasses = useContentStyles();
   const canEdit = props.light.type === LightType.RVL;
-  const zone = props.zones.find((zone) => zone.id === props.light.zoneId);
+  let zone: Zone | undefined;
+  if (props.light.zoneId !== undefined) {
+    zone = getItem(props.light.zoneId, props.zones);
+  }
   return (
     <ListItem className={contentClasses.listItem}>
       {canEdit ? (

--- a/client/src/components/scene/createSceneButton.tsx
+++ b/client/src/components/scene/createSceneButton.tsx
@@ -21,7 +21,9 @@ import { Button } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { Add as AddIcon } from '@material-ui/icons';
 import React, { FunctionComponent } from 'react';
+import { MAX_BRIGHTNESS, BRIGHTNESS_STEP } from '../../common/config';
 import { Light, Pattern, SceneLightEntry } from '../../common/types';
+import { getItem } from '../../common/util';
 import { FormInput, FormSchema, FormSchemaType } from '../lib/formInput';
 
 const useStyles = makeStyles({
@@ -73,12 +75,7 @@ export const CreateSceneButton: FunctionComponent<
       const match = /^brightness-([0-9]*)$/.exec(value);
       if (match) {
         const lightId = parseInt(match[1]);
-        const light = lights.find((light) => light.lightId === lightId);
-        if (!light) {
-          throw new Error(
-            `Internal Error: could not find brightness entry for light ${lightId}`
-          );
-        }
+        const light = getItem(lightId, lights, 'lightId');
         light.brightness = parseInt(values[value]);
       }
     }
@@ -116,8 +113,9 @@ export const CreateSceneButton: FunctionComponent<
       name: `brightness-${light.id}`,
       description: 'Brightness',
       min: 0,
-      max: 255,
-      defaultValue: 255
+      max: MAX_BRIGHTNESS,
+      step: BRIGHTNESS_STEP,
+      defaultValue: MAX_BRIGHTNESS
     });
   }
 

--- a/client/src/components/scene/editSceneButton.tsx
+++ b/client/src/components/scene/editSceneButton.tsx
@@ -21,6 +21,7 @@ import { Button, Fade } from '@material-ui/core';
 import { Edit as EditIcon } from '@material-ui/icons';
 import React, { FunctionComponent } from 'react';
 import { Light, Pattern, Scene, SceneLightEntry } from '../../common/types';
+import { getItem } from '../../common/util';
 import { FormInput, FormSchema, FormSchemaType } from '../lib/formInput';
 import { useContentStyles } from '../lib/pageStyles';
 
@@ -62,12 +63,7 @@ export const EditSceneButton: FunctionComponent<
       const match = /^brightness-([0-9]*)$/.exec(value);
       if (match) {
         const lightId = parseInt(match[1]);
-        const light = lights.find((light) => light.lightId === lightId);
-        if (!light) {
-          throw new Error(
-            `Internal Error: could not find brightness entry for light ${lightId}`
-          );
-        }
+        const light = getItem(lightId, lights, 'lightId');
         light.brightness = parseInt(values[value]);
       }
     }
@@ -89,22 +85,10 @@ export const EditSceneButton: FunctionComponent<
     }
   ];
   for (const lightEntry of props.scene.lights) {
-    const light = props.lights.find((light) => light.id === lightEntry.lightId);
-    if (!light) {
-      throw new Error(
-        `Internal Error: could not find light with ID ${lightEntry.lightId}`
-      );
-    }
-    let pattern;
-    if (lightEntry.patternId) {
-      pattern = props.patterns.find(
-        (pattern) => pattern.id === lightEntry.patternId
-      );
-      if (!pattern) {
-        throw new Error(
-          `Internal Error: could not find pattern with ID ${lightEntry.patternId}`
-        );
-      }
+    const light = getItem(lightEntry.lightId, props.lights);
+    let pattern: Pattern | undefined;
+    if (lightEntry.patternId !== undefined) {
+      pattern = getItem(lightEntry.patternId, props.patterns);
     }
     spec.push({
       type: FormSchemaType.Label,

--- a/client/src/components/scene/sceneComponent.tsx
+++ b/client/src/components/scene/sceneComponent.tsx
@@ -31,9 +31,12 @@ import {
 export interface SceneComponentProps {
   scene: Scene;
   editMode: EditMode;
+  selected: boolean;
 }
 
-export type SceneComponentDispatch = DeleteSceneButtonDispatch;
+export type SceneComponentDispatch = DeleteSceneButtonDispatch & {
+  setZoneScene: (zoneId: number, sceneId: number) => void;
+};
 
 const EditSceneComponent: FunctionComponent<
   SceneComponentProps & SceneComponentDispatch
@@ -58,8 +61,13 @@ const OperationSceneComponent: FunctionComponent<
 > = (props) => {
   const classes = useContentStyles();
   return (
-    <ListItem className={classes.listItem} button>
-      <Typography className={classes.itemTitle}>{props.scene.name}</Typography>
+    <ListItem className={classes.listItem} button selected={props.selected}>
+      <Typography
+        className={classes.itemTitle}
+        onClick={() => props.setZoneScene(props.scene.zoneId, props.scene.id)}
+      >
+        {props.scene.name}
+      </Typography>
     </ListItem>
   );
 };

--- a/client/src/components/scene/zoneScenesComponent.tsx
+++ b/client/src/components/scene/zoneScenesComponent.tsx
@@ -20,7 +20,7 @@ along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 import { Divider, List } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import React, { Fragment, FunctionComponent } from 'react';
-import { Light, Scene, Zone } from '../../common/types';
+import { Light, Scene, Zone, ZoneState } from '../../common/types';
 import { CreateSceneButtonContainer } from '../../containers/createSceneButtonContainer';
 import { EditMode } from '../../types';
 import { SceneComponent, SceneComponentDispatch } from './sceneComponent';
@@ -30,6 +30,7 @@ export interface ZoneScenesComponentProps {
   zoneScenes: Scene[];
   zoneLights: Light[];
   editMode: EditMode;
+  state: ZoneState;
 }
 
 export type ZoneScenesComponentDispatch = SceneComponentDispatch;
@@ -56,7 +57,9 @@ export const ZoneScenesComponent: FunctionComponent<
             <SceneComponent
               scene={scene}
               editMode={props.editMode}
+              setZoneScene={props.setZoneScene}
               deleteScene={props.deleteScene}
+              selected={props.state.currentSceneId === scene.id}
             />
           </Fragment>
         ))}

--- a/client/src/components/zone/zoneComponent.tsx
+++ b/client/src/components/zone/zoneComponent.tsx
@@ -21,11 +21,14 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
-  Typography
+  Typography,
+  Slider
 } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import { ExpandMore as ExpandMoreIcon } from '@material-ui/icons';
 import React, { FunctionComponent } from 'react';
-import { Zone } from '../../common/types';
+import { BRIGHTNESS_STEP, MAX_BRIGHTNESS } from '../../common/config';
+import { Scene, Zone, ZoneState } from '../../common/types';
 import { ZoneScenesContainer } from '../../containers/zoneScenesContainer';
 import { EditMode } from '../../types';
 import { useContentStyles } from '../lib/pageStyles';
@@ -33,48 +36,80 @@ import { DeleteZoneButton, DeleteZoneButtonDispatch } from './deleteZoneButton';
 import { EditZoneButton, EditZoneButtonDispatch } from './editZoneButton';
 import { ZonePowerSwitch, ZonePowerSwitchDispatch } from './zonePowerSwitch';
 
+const useStyles = makeStyles({
+  container: {
+    width: '100%'
+  }
+});
+
 export interface ZoneComponentProps {
   zone: Zone;
   editMode: EditMode;
+  state: ZoneState;
+  currentScene?: Scene;
 }
 
 export type ZoneComponentDispatch = EditZoneButtonDispatch &
   DeleteZoneButtonDispatch &
-  ZonePowerSwitchDispatch;
+  ZonePowerSwitchDispatch & {
+    setZoneBrightness: (zoneId: number, brightness: number) => void;
+  };
 
 export const ZoneComponent: FunctionComponent<
   ZoneComponentProps & ZoneComponentDispatch
 > = (props) => {
-  const classes = useContentStyles();
+  const classes = useStyles();
+  const contentClasses = useContentStyles();
   return (
     <React.Fragment>
       <Accordion>
         <AccordionSummary expandIcon={<ExpandMoreIcon />} id="panel1a-header">
-          <div className={classes.itemHeading}>
-            <DeleteZoneButton
-              zone={props.zone}
-              editMode={props.editMode}
-              className={classes.leftButton}
-              deleteZone={props.deleteZone}
-            />
-            <ZonePowerSwitch
-              className={classes.leftButton}
-              zone={props.zone}
-              editMode={props.editMode}
-              toggleZonePower={props.toggleZonePower}
-            />
-            <Typography className={classes.itemTitle}>
-              {props.zone.name}
-            </Typography>
-            <EditZoneButton
-              className={classes.rightAccordionButton}
-              zone={props.zone}
-              editMode={props.editMode}
-              editZone={props.editZone}
-            />
+          <div className={classes.container}>
+            <div className={contentClasses.itemHeading}>
+              <DeleteZoneButton
+                zone={props.zone}
+                editMode={props.editMode}
+                className={contentClasses.leftButton}
+                deleteZone={props.deleteZone}
+              />
+              <ZonePowerSwitch
+                className={contentClasses.leftButton}
+                zone={props.zone}
+                editMode={props.editMode}
+                setZonePower={props.setZonePower}
+                defaultChecked={props.state.power}
+              />
+              <Typography className={contentClasses.itemTitle}>
+                {props.zone.name}
+              </Typography>
+              <EditZoneButton
+                className={contentClasses.rightAccordionButton}
+                zone={props.zone}
+                editMode={props.editMode}
+                editZone={props.editZone}
+              />
+            </div>
+            <div>
+              <Slider
+                disabled={props.state.currentSceneId === undefined}
+                value={props.currentScene ? props.currentScene.brightness : 0}
+                valueLabelDisplay="auto"
+                step={BRIGHTNESS_STEP}
+                min={0}
+                max={MAX_BRIGHTNESS}
+                onChange={(e, newValue) => {
+                  if (Array.isArray(newValue)) {
+                    throw new Error(
+                      'Internal Error: expected number but got number[]'
+                    );
+                  }
+                  props.setZoneBrightness(props.zone.id, newValue);
+                }}
+              />
+            </div>
           </div>
         </AccordionSummary>
-        <AccordionDetails className={classes.detailContainer}>
+        <AccordionDetails className={contentClasses.detailContainer}>
           <ZoneScenesContainer zone={props.zone} editMode={props.editMode} />
         </AccordionDetails>
       </Accordion>

--- a/client/src/components/zone/zonePowerSwitch.tsx
+++ b/client/src/components/zone/zonePowerSwitch.tsx
@@ -26,10 +26,11 @@ export interface ZonePowerSwitchProps {
   zone: Zone;
   editMode: EditMode;
   className: string;
+  defaultChecked: boolean;
 }
 
 export interface ZonePowerSwitchDispatch {
-  toggleZonePower: (id: number, powerState: boolean) => void;
+  setZonePower: (id: number, powerState: boolean) => void;
 }
 
 export const ZonePowerSwitch: FunctionComponent<
@@ -45,8 +46,9 @@ export const ZonePowerSwitch: FunctionComponent<
             e.stopPropagation();
           }}
           onChange={(e) =>
-            props.toggleZonePower(props.zone.id, e.currentTarget.checked)
+            props.setZonePower(props.zone.id, e.currentTarget.checked)
           }
+          checked={props.defaultChecked}
         />
       )}
     </React.Fragment>

--- a/client/src/components/zone/zonesTab.tsx
+++ b/client/src/components/zone/zonesTab.tsx
@@ -20,7 +20,8 @@ along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 import { Button, Fade } from '@material-ui/core';
 import { Edit as EditIcon, Close as CloseIcon } from '@material-ui/icons';
 import React, { FunctionComponent } from 'react';
-import { Zone } from '../../common/types';
+import { Scene, SystemState, Zone } from '../../common/types';
+import { getItem } from '../../common/util';
 import { EditMode } from '../../types';
 import { useContainerStyles } from '../lib/pageStyles';
 import { CreateZoneButton } from './createZoneButton';
@@ -28,13 +29,16 @@ import { ZoneComponent } from './zoneComponent';
 
 export interface ZonesTabProps {
   zones: Zone[];
+  scenes: Scene[];
+  state: SystemState;
 }
 
 export interface ZonesTabDispatch {
   createZone: (name: string) => void;
   editZone: (zone: Zone) => void;
   deleteZone: (id: number) => void;
-  toggleZonePower: (id: number, powerState: boolean) => void;
+  setZonePower: (id: number, powerState: boolean) => void;
+  setZoneBrightness: (id: number, brightness: number) => void;
 }
 
 export const ZonesTab: FunctionComponent<ZonesTabProps & ZonesTabDispatch> = (
@@ -70,16 +74,25 @@ export const ZonesTab: FunctionComponent<ZonesTabProps & ZonesTabDispatch> = (
 
       <div className={classes.content}>
         <div className={classes.innerContent}>
-          {props.zones.map((zone) => (
-            <ZoneComponent
-              key={zone.id}
-              zone={zone}
-              editMode={editMode}
-              editZone={props.editZone}
-              deleteZone={props.deleteZone}
-              toggleZonePower={props.toggleZonePower}
-            />
-          ))}
+          {props.zones.map((zone) => {
+            const state = getItem(zone.id, props.state.zoneStates, 'zoneId');
+            const currentScene = props.scenes.find(
+              (scene) => scene.id === state.currentSceneId
+            );
+            return (
+              <ZoneComponent
+                key={zone.id}
+                zone={zone}
+                state={state}
+                editMode={editMode}
+                editZone={props.editZone}
+                deleteZone={props.deleteZone}
+                setZonePower={props.setZonePower}
+                setZoneBrightness={props.setZoneBrightness}
+                currentScene={currentScene}
+              />
+            );
+          })}
         </div>
       </div>
     </div>

--- a/client/src/containers/zoneScenesContainer.tsx
+++ b/client/src/containers/zoneScenesContainer.tsx
@@ -18,6 +18,7 @@ along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { Zone } from '../common/types';
+import { getItem } from '../common/util';
 import {
   ZoneScenesComponent,
   ZoneScenesComponentProps,
@@ -32,17 +33,28 @@ export interface ZoneScenesContainerProps {
 }
 
 export const ZoneScenesContainer = createContainer(
-  (getState, ownProps: ZoneScenesContainerProps): ZoneScenesComponentProps => ({
-    zone: ownProps.zone,
-    zoneScenes: getState(SliceName.Scenes).filter(
-      (scene) => scene.zoneId === ownProps.zone.id
-    ),
-    zoneLights: [],
-    editMode: ownProps.editMode
-  }),
+  (getState, ownProps: ZoneScenesContainerProps): ZoneScenesComponentProps => {
+    const state = getItem(
+      ownProps.zone.id,
+      getState(SliceName.State).zoneStates,
+      'zoneId'
+    );
+    return {
+      zone: ownProps.zone,
+      zoneScenes: getState(SliceName.Scenes).filter(
+        (scene) => scene.zoneId === ownProps.zone.id
+      ),
+      zoneLights: [],
+      editMode: ownProps.editMode,
+      state
+    };
+  },
   (dispatch): ZoneScenesComponentDispatch => ({
     deleteScene(id) {
       dispatch(ActionType.DeleteScene, id);
+    },
+    setZoneScene(zoneId, sceneId) {
+      dispatch(ActionType.SetZoneScene, { zoneId, sceneId });
     }
   }),
   ZoneScenesComponent

--- a/client/src/containers/zonesTabContainer.tsx
+++ b/client/src/containers/zonesTabContainer.tsx
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+import debounce from 'debounce';
 import {
   ZonesTab,
   ZonesTabProps,
@@ -27,7 +28,9 @@ import { SliceName, ActionType } from '../types';
 
 export const ZonesTabContainer = createContainer(
   (getState): ZonesTabProps => ({
-    zones: getState(SliceName.Zones)
+    zones: getState(SliceName.Zones),
+    state: getState(SliceName.State),
+    scenes: getState(SliceName.Scenes)
   }),
   (dispatch): ZonesTabDispatch => ({
     createZone(name) {
@@ -39,10 +42,12 @@ export const ZonesTabContainer = createContainer(
     deleteZone(id) {
       dispatch(ActionType.DeleteZone, id);
     },
-    toggleZonePower(id, powerState) {
-      console.log(`Toggling zone ${id} power to ${powerState}`);
-      // TODO
-    }
+    setZonePower(zoneId, power) {
+      dispatch(ActionType.SetZonePower, { zoneId, power });
+    },
+    setZoneBrightness: debounce((zoneId, brightness) => {
+      dispatch(ActionType.SetZoneBrightness, { zoneId, brightness });
+    }, 33)
   }),
   ZonesTab
 );

--- a/client/src/listeners/lightsListeners.ts
+++ b/client/src/listeners/lightsListeners.ts
@@ -17,10 +17,10 @@ You should have received a copy of the GNU General Public License
 along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { CreateRVLLightRequest, Light, LightType } from '../common/types';
+import { CreateRVLLightRequest, LightType } from '../common/types';
 import { createListener, dispatch } from '../reduxology';
 import { ActionType } from '../types';
-import { get, post, put, del } from '../util/api';
+import { post, put, del } from '../util/api';
 
 const createRVLLightListener = createListener(
   ActionType.CreateRVLLight,
@@ -31,30 +31,24 @@ const createRVLLightListener = createListener(
       channel,
       zoneId
     };
-    await post('/api/lights', createBody);
-
-    const updatedLights = (await get('/api/lights')) as Light[];
-    dispatch(ActionType.LightsUpdated, updatedLights);
+    const appState = await post('/api/lights', createBody);
+    dispatch(ActionType.AppStateUpdated, appState);
   }
 );
 
 const editLightListener = createListener(
   ActionType.EditLight,
   async (light) => {
-    await put(`/api/light/${light.id}`, light);
-
-    const updatedLights = (await get('/api/lights')) as Light[];
-    dispatch(ActionType.LightsUpdated, updatedLights);
+    const appState = await put(`/api/light/${light.id}`, light);
+    dispatch(ActionType.AppStateUpdated, appState);
   }
 );
 
 const deleteLightListener = createListener(
   ActionType.DeleteLight,
   async (id) => {
-    await del(`/api/light/${id}`);
-
-    const updatedLights = (await get('/api/lights')) as Light[];
-    dispatch(ActionType.LightsUpdated, updatedLights);
+    const appState = await del(`/api/light/${id}`);
+    dispatch(ActionType.AppStateUpdated, appState);
   }
 );
 

--- a/client/src/listeners/listeners.ts
+++ b/client/src/listeners/listeners.ts
@@ -19,10 +19,12 @@ along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 
 import { lightsListeners } from './lightsListeners';
 import { sceneListeners } from './sceneListeners';
+import { stateListeners } from './stateListeners';
 import { zonesListeners } from './zonesListeners';
 
 export const listeners = [
   ...zonesListeners,
   ...sceneListeners,
-  ...lightsListeners
+  ...lightsListeners,
+  ...stateListeners
 ];

--- a/client/src/listeners/sceneListeners.ts
+++ b/client/src/listeners/sceneListeners.ts
@@ -17,10 +17,10 @@ You should have received a copy of the GNU General Public License
 along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { CreateSceneRequest, Scene } from '../common/types';
+import { CreateSceneRequest } from '../common/types';
 import { createListener, dispatch } from '../reduxology';
 import { ActionType } from '../types';
-import { get, del, post, put } from '../util/api';
+import { del, post, put } from '../util/api';
 
 const createScenesListener = createListener(
   ActionType.CreateScene,
@@ -30,30 +30,24 @@ const createScenesListener = createListener(
       zoneId,
       lights
     };
-    await post('/api/scenes', createBody);
-
-    const updatedScenes = (await get('/api/scenes')) as Scene[];
-    dispatch(ActionType.ScenesUpdated, updatedScenes);
+    const appState = await post('/api/scenes', createBody);
+    dispatch(ActionType.AppStateUpdated, appState);
   }
 );
 
 const editSceneListener = createListener(
   ActionType.EditScene,
   async (scene) => {
-    await put(`/api/scene/${scene.id}`, scene);
-
-    const updatedScenes = (await get('/api/scenes')) as Scene[];
-    dispatch(ActionType.ScenesUpdated, updatedScenes);
+    const appState = await put(`/api/scene/${scene.id}`, scene);
+    dispatch(ActionType.AppStateUpdated, appState);
   }
 );
 
 const deleteSceneListener = createListener(
   ActionType.DeleteScene,
   async (id) => {
-    await del(`/api/scene/${id}`);
-
-    const updatedScenes = (await get('/api/scenes')) as Scene[];
-    dispatch(ActionType.ScenesUpdated, updatedScenes);
+    const appState = await del(`/api/scene/${id}`);
+    dispatch(ActionType.AppStateUpdated, appState);
   }
 );
 

--- a/client/src/listeners/stateListeners.ts
+++ b/client/src/listeners/stateListeners.ts
@@ -1,0 +1,73 @@
+/*
+Copyright (c) Bryan Hughes <bryan@nebri.us>
+
+This file is part of Home Lights.
+
+Home Lights is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Home Lights is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import {
+  SetZoneBrightnessRequest,
+  SetZonePowerRequest,
+  SetZoneSceneRequest
+} from '../common/types';
+import { getItem } from '../common/util';
+import { createListener, dispatch } from '../reduxology';
+import { ActionType, SliceName } from '../types';
+import { post } from '../util/api';
+
+const setZoneScene = createListener(
+  ActionType.SetZoneScene,
+  async ({ zoneId, sceneId }, getSlice) => {
+    const state = getSlice(SliceName.State);
+    const zoneState = getItem(zoneId, state.zoneStates, 'zoneId');
+    if (!zoneState.power) {
+      await setZonePowerListener({ zoneId, power: true });
+    }
+    const setZoneSceneBody: SetZoneSceneRequest = { sceneId };
+    const appState = await post('/api/state-scene', setZoneSceneBody);
+    dispatch(ActionType.AppStateUpdated, appState);
+  }
+);
+
+const setZoneBrightness = createListener(
+  ActionType.SetZoneBrightness,
+  async ({ zoneId, brightness }) => {
+    const setZoneBrightnessBody: SetZoneBrightnessRequest = {
+      zoneId,
+      brightness
+    };
+    const appState = await post('/api/state-brightness', setZoneBrightnessBody);
+    dispatch(ActionType.AppStateUpdated, appState);
+  }
+);
+
+async function setZonePowerListener({
+  zoneId,
+  power
+}: {
+  zoneId: number;
+  power: boolean;
+}) {
+  const setZonePowerBody: SetZonePowerRequest = { zoneId, power };
+  const appState = await post('/api/state-power', setZonePowerBody);
+  dispatch(ActionType.AppStateUpdated, appState);
+}
+
+const setZonePower = createListener(
+  ActionType.SetZonePower,
+  setZonePowerListener
+);
+
+export const stateListeners = [setZoneScene, setZoneBrightness, setZonePower];

--- a/client/src/listeners/zonesListeners.ts
+++ b/client/src/listeners/zonesListeners.ts
@@ -17,34 +17,28 @@ You should have received a copy of the GNU General Public License
 along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { CreateZoneRequest, Zone } from '../common/types';
+import { CreateZoneRequest } from '../common/types';
 import { createListener, dispatch } from '../reduxology';
 import { ActionType } from '../types';
-import { get, post, put, del } from '../util/api';
+import { post, put, del } from '../util/api';
 
 const createZoneListener = createListener(
   ActionType.CreateZone,
   async (name) => {
     const createBody: CreateZoneRequest = { name };
-    await post('/api/zones', createBody);
-
-    const updatedZones = (await get('/api/zones')) as Zone[];
-    dispatch(ActionType.ZonesUpdated, updatedZones);
+    const appState = await post('/api/zones', createBody);
+    dispatch(ActionType.AppStateUpdated, appState);
   }
 );
 
 const editZoneListener = createListener(ActionType.EditZone, async (zone) => {
-  await put(`/api/zone/${zone.id}`, zone);
-
-  const updatedZones = (await get('/api/zones')) as Zone[];
-  dispatch(ActionType.ZonesUpdated, updatedZones);
+  const appState = await put(`/api/zone/${zone.id}`, zone);
+  dispatch(ActionType.AppStateUpdated, appState);
 });
 
 const deleteZoneListener = createListener(ActionType.DeleteZone, async (id) => {
-  await del(`/api/zone/${id}`);
-
-  const updatedZones = (await get('/api/zones')) as Zone[];
-  dispatch(ActionType.ZonesUpdated, updatedZones);
+  const appState = await del(`/api/zone/${id}`);
+  dispatch(ActionType.AppStateUpdated, appState);
 });
 
 export const zonesListeners = [

--- a/client/src/reducers/lightsReducer.ts
+++ b/client/src/reducers/lightsReducer.ts
@@ -17,12 +17,19 @@ You should have received a copy of the GNU General Public License
 along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { Light } from '../common/types';
 import { createReducer } from '../reduxology';
 import { SliceName, ActionType } from '../types';
 
-export const lightsReducer = createReducer(SliceName.Lights, []);
+// Typing this return type explicitly is very hard, but can be inferred easily
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function createLightsReducers(initialPatterns: Light[]) {
+  const lightsReducer = createReducer(SliceName.Lights, initialPatterns);
 
-lightsReducer.handle(
-  ActionType.LightsUpdated,
-  (state, updatedLights) => updatedLights
-);
+  lightsReducer.handle(
+    ActionType.AppStateUpdated,
+    (state, { lights }) => lights
+  );
+
+  return lightsReducer;
+}

--- a/client/src/reducers/patternsReducer.ts
+++ b/client/src/reducers/patternsReducer.ts
@@ -17,12 +17,19 @@ You should have received a copy of the GNU General Public License
 along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { Pattern } from '../common/types';
 import { createReducer } from '../reduxology';
 import { ActionType, SliceName } from '../types';
 
-export const patternsReducer = createReducer(SliceName.Patterns, []);
+// Typing this return type explicitly is very hard, but can be inferred easily
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function createPatternsReducers(initialPatterns: Pattern[]) {
+  const patternsReducer = createReducer(SliceName.Patterns, initialPatterns);
 
-patternsReducer.handle(
-  ActionType.PatternsUpdated,
-  (state, updatedPatterns) => updatedPatterns
-);
+  patternsReducer.handle(
+    ActionType.AppStateUpdated,
+    (state, { patterns }) => patterns
+  );
+
+  return patternsReducer;
+}

--- a/client/src/reducers/scenesReducer.ts
+++ b/client/src/reducers/scenesReducer.ts
@@ -17,12 +17,19 @@ You should have received a copy of the GNU General Public License
 along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { Scene } from '../common/types';
 import { createReducer } from '../reduxology';
 import { SliceName, ActionType } from '../types';
 
-export const scenesReducer = createReducer(SliceName.Scenes, []);
+// Typing this return type explicitly is very hard, but can be inferred easily
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function createScenesReducers(initialScenes: Scene[]) {
+  const scenesReducer = createReducer(SliceName.Scenes, initialScenes);
 
-scenesReducer.handle(
-  ActionType.ScenesUpdated,
-  (state, updatedScenes) => updatedScenes
-);
+  scenesReducer.handle(
+    ActionType.AppStateUpdated,
+    (state, { scenes }) => scenes
+  );
+
+  return scenesReducer;
+}

--- a/client/src/reducers/stateReducer.ts
+++ b/client/src/reducers/stateReducer.ts
@@ -17,12 +17,19 @@ You should have received a copy of the GNU General Public License
 along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { FastifyInstance } from 'fastify';
-import { createScene, editScene, deleteScene } from '../db/scenes';
-import { post, put, del } from './endpoint';
+import { SystemState } from '../common/types';
+import { createReducer } from '../reduxology';
+import { SliceName, ActionType } from '../types';
 
-export function init(app: FastifyInstance): void {
-  app.post('/api/scenes', post(createScene));
-  app.put('/api/scene/:id', put(editScene));
-  app.delete('/api/scene/:id', del(deleteScene));
+// Typing this return type explicitly is very hard, but can be inferred easily
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function createStateReducers(initialSystemState: SystemState) {
+  const stateReducer = createReducer(SliceName.State, initialSystemState);
+
+  stateReducer.handle(
+    ActionType.AppStateUpdated,
+    (state, { systemState }) => systemState
+  );
+
+  return stateReducer;
 }

--- a/client/src/reducers/zonesReducer.ts
+++ b/client/src/reducers/zonesReducer.ts
@@ -17,12 +17,16 @@ You should have received a copy of the GNU General Public License
 along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { Zone } from '../common/types';
 import { createReducer } from '../reduxology';
 import { SliceName, ActionType } from '../types';
 
-export const zonesReducer = createReducer(SliceName.Zones, []);
+// Typing this return type explicitly is very hard, but can be inferred easily
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function createZonesReducers(initialZones: Zone[]) {
+  const zonesReducer = createReducer(SliceName.Zones, initialZones);
 
-zonesReducer.handle(
-  ActionType.ZonesUpdated,
-  (state, updateZones) => updateZones
-);
+  zonesReducer.handle(ActionType.AppStateUpdated, (state, { zones }) => zones);
+
+  return zonesReducer;
+}

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -21,9 +21,11 @@ import {
   CreatePatternRequest,
   CreateSceneRequest,
   Light,
+  SystemState,
   Pattern,
   Scene,
-  Zone
+  Zone,
+  AppState
 } from './common/types';
 
 export enum SliceName {
@@ -32,11 +34,17 @@ export enum SliceName {
   Patterns = 'Patterns',
   Lights = 'Lights',
   Colors = 'Colors',
-  SelectedTab = 'SelectedTab'
+  SelectedTab = 'SelectedTab',
+  State = 'State'
 }
 
 export enum ActionType {
   SelectTab = 'SelectTab',
+
+  AppStateUpdated = 'StateUpdated',
+  SetZoneScene = 'SetZoneScene',
+  SetZonePower = 'SetZonePower',
+  SetZoneBrightness = 'SetZoneBrightness',
 
   ZonesUpdated = 'ZonesUpdated',
   CreateZone = 'CreateZone',
@@ -65,27 +73,30 @@ export interface State {
   [SliceName.Lights]: Light[];
   [SliceName.SelectedTab]: SelectedTab;
   [SliceName.Patterns]: Pattern[];
+  [SliceName.State]: SystemState;
 }
 
 export interface Actions {
   [ActionType.SelectTab]: SelectedTab;
 
-  [ActionType.ZonesUpdated]: Zone[];
+  [ActionType.AppStateUpdated]: AppState;
+
+  [ActionType.SetZoneScene]: { zoneId: number; sceneId: number };
+  [ActionType.SetZonePower]: { zoneId: number; power: boolean };
+  [ActionType.SetZoneBrightness]: { zoneId: number; brightness: number };
+
   [ActionType.CreateZone]: string;
   [ActionType.EditZone]: Zone;
   [ActionType.DeleteZone]: number;
 
-  [ActionType.ScenesUpdated]: Scene[];
   [ActionType.CreateScene]: CreateSceneRequest;
   [ActionType.EditScene]: Scene;
   [ActionType.DeleteScene]: number;
 
-  [ActionType.PatternsUpdated]: Pattern[];
   [ActionType.CreatePattern]: CreatePatternRequest;
   [ActionType.EditPattern]: Pattern;
   [ActionType.DeletePattern]: number;
 
-  [ActionType.LightsUpdated]: Light[];
   [ActionType.CreateRVLLight]: {
     name: string;
     channel: number;

--- a/client/src/util/api.ts
+++ b/client/src/util/api.ts
@@ -17,33 +17,29 @@ You should have received a copy of the GNU General Public License
 along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-export async function get(route: string): Promise<Record<string, any>> {
-  return send(route, 'GET');
+import { AppState } from '../common/types';
+
+export async function get<T>(route: string): Promise<T> {
+  return send(route, 'GET') as Promise<T>;
 }
 
-export async function post(
-  route: string,
-  body: Record<string, any>
-): Promise<Record<string, any>> {
-  return send(route, 'POST', body);
+export async function post(route: string, body: unknown): Promise<AppState> {
+  return send(route, 'POST', body) as Promise<AppState>;
 }
 
-export async function put(
-  route: string,
-  body: Record<string, any>
-): Promise<Record<string, any>> {
-  return send(route, 'PUT', body);
+export async function put(route: string, body: unknown): Promise<AppState> {
+  return send(route, 'PUT', body) as Promise<AppState>;
 }
 
-export async function del(route: string): Promise<Record<string, any>> {
-  return send(route, 'DELETE');
+export async function del(route: string): Promise<AppState> {
+  return send(route, 'DELETE') as Promise<AppState>;
 }
 
 async function send(
   route: string,
   method: string,
-  body?: Record<string, any>
-): Promise<Record<string, any>> {
+  body?: unknown
+): Promise<unknown> {
   const options: RequestInit = { method, credentials: 'same-origin' };
   if (body) {
     const headers = new Headers();

--- a/common/config.ts
+++ b/common/config.ts
@@ -1,3 +1,27 @@
+/*
+Copyright (c) Bryan Hughes <bryan@nebri.us>
+
+This file is part of Home Lights.
+
+Home Lights is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Home Lights is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// ---- General Configuration ----
+
+export const MAX_BRIGHTNESS = 255;
+export const BRIGHTNESS_STEP = 1;
+
 // ---- RVL Configuration ----
 export const NUM_RVL_CHANNELS = 8;
 

--- a/common/types.ts
+++ b/common/types.ts
@@ -17,6 +17,16 @@ You should have received a copy of the GNU General Public License
 along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+// ---- App State ----
+
+export interface AppState {
+  zones: Zone[];
+  scenes: Scene[];
+  patterns: Pattern[];
+  lights: Light[];
+  systemState: SystemState;
+}
+
 // ---- Zone Types ----
 
 export interface Zone {
@@ -71,9 +81,10 @@ export interface Scene {
   id: number;
   zoneId: number;
   name: string;
+  brightness: number;
   lights: SceneLightEntry[];
 }
-export type CreateSceneRequest = Omit<Scene, 'id'>;
+export type CreateSceneRequest = Omit<Scene, 'id' | 'brightness'>;
 
 // ---- Pattern Types ----
 
@@ -142,13 +153,28 @@ export interface WavePattern extends Pattern {
 }
 export type CreateWavePatternRequest = Omit<WavePattern, 'id'>;
 
-// ---- Light State ----
+// ---- System State ----
 
-export interface RoomLightState {
+export interface ZoneState {
+  zoneId: number;
   power: boolean;
-  scene: Scene;
+  currentSceneId: number | undefined;
 }
 
-export interface SetLightStateRequest {
-  rooms: RoomLightState[];
+export interface SystemState {
+  zoneStates: ZoneState[];
 }
+
+export type SetZoneSceneRequest = {
+  sceneId: number;
+};
+
+export type SetZonePowerRequest = {
+  zoneId: number;
+  power: boolean;
+};
+
+export type SetZoneBrightnessRequest = {
+  zoneId: number;
+  brightness: number;
+};

--- a/common/util.ts
+++ b/common/util.ts
@@ -17,12 +17,22 @@ You should have received a copy of the GNU General Public License
 along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { FastifyInstance } from 'fastify';
-import { createScene, editScene, deleteScene } from '../db/scenes';
-import { post, put, del } from './endpoint';
-
-export function init(app: FastifyInstance): void {
-  app.post('/api/scenes', post(createScene));
-  app.put('/api/scene/:id', put(editScene));
-  app.delete('/api/scene/:id', del(deleteScene));
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getItem<K, T extends Record<string, any>>(
+  id: K,
+  items: T[],
+  lookup?: ((item: T) => boolean) | string
+): T {
+  if (!lookup) {
+    lookup = (item) => item.id === id;
+  }
+  if (typeof lookup === 'string') {
+    const key = lookup;
+    lookup = (item) => item[key] === id;
+  }
+  const item = items.find(lookup);
+  if (!item) {
+    throw new Error(`Internal Error: could not find item ${id}`);
+  }
+  return item;
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1699,9 +1699,9 @@
       }
     },
     "rvl-node": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/rvl-node/-/rvl-node-6.0.1.tgz",
-      "integrity": "sha512-WgMR7hvv5vP+u/ctDvXR6tOESm3F7r+uZiZoq2mu0fJztQ0j2QdxDKDaZzmLwCcs9qjgN6Zi7JSxfMu3/3hIvQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/rvl-node/-/rvl-node-6.1.0.tgz",
+      "integrity": "sha512-Ie34lzLl+F3sM7xP4DcQBEM7qJ/YbT4f+Jiy2GMpzoSBcSYhK4IgtPehzls+kAOy0LDquwgBBr0oSpAKXc3zAQ==",
       "requires": {
         "strict-event-emitter-types": "^2.0.0"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -25,7 +25,7 @@
     "fastify-static": "^3.2.1",
     "node-fetch": "^2.6.1",
     "node-hue-api": "^4.0.9",
-    "rvl-node": "^6.0.1",
+    "rvl-node": "^6.1.0",
     "sqlite3": "^5.0.0"
   }
 }

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -19,19 +19,28 @@ along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 
 import { existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
-import { LIGHTS_SCHEMA, LIGHTS_TABLE_NAME } from './db/lights';
+import {
+  LIGHTS_SCHEMA,
+  LIGHTS_TABLE_NAME,
+  init as initLights
+} from './db/lights';
 import {
   PATTERNS_SCHEMA,
   PATTERNS_TABLE_NAME,
   COLORS_SCHEMA,
-  COLORS_TABLE_NAME
+  COLORS_TABLE_NAME,
+  init as initPatterns
 } from './db/patterns';
 import {
   PHILIPS_HUE_INFO_SCHEMA,
   PHILIPS_HUE_TABLE_NAME
 } from './db/philipsHue';
-import { SCENES_SCHEMA, SCENES_TABLE_NAME } from './db/scenes';
-import { ZONES_SCHEMA, ZONES_TABLE_NAME } from './db/zones';
+import {
+  SCENES_SCHEMA,
+  SCENES_TABLE_NAME,
+  init as initScenes
+} from './db/scenes';
+import { ZONES_SCHEMA, ZONES_TABLE_NAME, init as initZones } from './db/zones';
 import { init as initDB, dbRun, dbAll } from './sqlite';
 import { getEnvironmentVariable } from './util';
 
@@ -79,5 +88,8 @@ export async function init(): Promise<void> {
   if (isNewDB) {
     await create();
   }
+
+  await Promise.all([initZones(), initScenes(), initPatterns(), initLights()]);
+
   console.log('Database initialized');
 }

--- a/server/src/db/lights.ts
+++ b/server/src/db/lights.ts
@@ -44,9 +44,11 @@ CREATE TABLE "${LIGHTS_TABLE_NAME}" (
   FOREIGN KEY (zone_id) REFERENCES zones(id)
 )`;
 
-export async function getLights(): Promise<Light[]> {
+let lights: Light[] = [];
+
+export async function init(): Promise<void> {
   const rawResults = await dbAll(`SELECT * FROM ${LIGHTS_TABLE_NAME}`);
-  return rawResults.map((light) => {
+  lights = rawResults.map((light) => {
     switch (light.type) {
       case LightType.RVL: {
         // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -56,7 +58,7 @@ export async function getLights(): Promise<Light[]> {
           name,
           type,
           channel,
-          zoneId
+          zoneId: typeof zoneId === 'number' ? zoneId : undefined
         };
         return rvlLight;
       }
@@ -75,7 +77,7 @@ export async function getLights(): Promise<Light[]> {
           name,
           type,
           philipsHueID,
-          zoneId
+          zoneId: typeof zoneId === 'number' ? zoneId : undefined
         };
         return hueLight;
       }
@@ -87,7 +89,7 @@ export async function getLights(): Promise<Light[]> {
           name,
           type,
           lifxId,
-          zoneId
+          zoneId: typeof zoneId === 'number' ? zoneId : undefined
         };
         return lifxLight;
       }
@@ -95,6 +97,10 @@ export async function getLights(): Promise<Light[]> {
         throw new Error(`Found unknown light type in database "${light.type}"`);
     }
   });
+}
+
+export function getLights(): Light[] {
+  return lights;
 }
 
 export async function createLight(
@@ -148,6 +154,7 @@ export async function createLight(
       break;
     }
   }
+  await init();
 }
 
 export async function editLight(light: Light): Promise<void> {
@@ -177,6 +184,7 @@ export async function editLight(light: Light): Promise<void> {
       break;
     }
   }
+  await init();
 }
 
 export async function deleteLight(id: number): Promise<void> {
@@ -184,4 +192,5 @@ export async function deleteLight(id: number): Promise<void> {
     id,
     LightType.RVL
   ]);
+  await init();
 }

--- a/server/src/db/zones.ts
+++ b/server/src/db/zones.ts
@@ -27,8 +27,14 @@ CREATE TABLE "${ZONES_TABLE_NAME}" (
   name TEXT NOT NULL UNIQUE
 )`;
 
-export async function getZones(): Promise<Zone[]> {
-  return dbAll(`SELECT * FROM ${ZONES_TABLE_NAME}`) as Promise<Zone[]>;
+let zones: Zone[] = [];
+
+export async function init(): Promise<void> {
+  zones = (await dbAll(`SELECT * FROM ${ZONES_TABLE_NAME}`)) as Zone[];
+}
+
+export function getZones(): Zone[] {
+  return zones;
 }
 
 export async function createZone(
@@ -37,6 +43,7 @@ export async function createZone(
   await dbRun(`INSERT INTO ${ZONES_TABLE_NAME} (name) VALUES (?)`, [
     zoneRequest.name
   ]);
+  await init();
 }
 
 export async function editZone(zone: Zone): Promise<void> {
@@ -44,8 +51,10 @@ export async function editZone(zone: Zone): Promise<void> {
     zone.name,
     zone.id
   ]);
+  await init();
 }
 
 export async function deleteZone(id: number): Promise<void> {
   await dbRun(`DELETE FROM ${ZONES_TABLE_NAME} WHERE id = ?`, [id]);
+  await init();
 }

--- a/server/src/device.ts
+++ b/server/src/device.ts
@@ -17,7 +17,12 @@ You should have received a copy of the GNU General Public License
 along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { SetLightStateRequest } from './common/types';
+import { SystemState, ZoneState } from './common/types';
+import { getItem } from './common/util';
+import { getLights } from './db/lights';
+import { getPatterns } from './db/patterns';
+import { getScenes, setSceneBrightness } from './db/scenes';
+import { getZones } from './db/zones';
 import {
   init as initLIFX,
   setLightState as setLIFXLightState
@@ -30,19 +35,101 @@ import {
   init as initRVL,
   setLightState as setPhilipsHueLightState
 } from './device/rvl';
+import { SetLightStateOptions } from './device/types';
+
+const systemState: SystemState = {
+  zoneStates: []
+};
 
 export async function init(): Promise<void> {
   await initRVL();
   await initPhilipsHue();
   await initLIFX();
+  const zones = await getZones();
+  for (const zone of zones) {
+    systemState.zoneStates.push({
+      zoneId: zone.id,
+      currentSceneId: undefined,
+      power: false
+    });
+  }
 }
 
-export async function setLightState(
-  lightState: SetLightStateRequest
+export async function reconcile(): Promise<void> {
+  const zones = await getZones();
+
+  // Add any new zones to state that were created
+  for (const zone of zones) {
+    if (
+      !systemState.zoneStates.find((zoneState) => zoneState.zoneId === zone.id)
+    ) {
+      systemState.zoneStates.push({
+        zoneId: zone.id,
+        currentSceneId: undefined,
+        power: false
+      });
+    }
+  }
+
+  // Remove any zones from zone state that were deleted
+  for (let i = systemState.zoneStates.length - 1; i >= 0; i--) {
+    const zoneState = systemState.zoneStates[i];
+    if (!zones.find((zone) => zone.id === zoneState.zoneId)) {
+      systemState.zoneStates.splice(i, 1);
+    }
+  }
+}
+
+export function getSystemState(): SystemState {
+  return systemState;
+}
+
+export async function setZoneScene(sceneId: number): Promise<void> {
+  const scene = getItem(sceneId, await getScenes());
+  const zoneState = getItem(scene.zoneId, systemState.zoneStates, 'zoneId');
+  zoneState.currentSceneId = sceneId;
+  setLightState(zoneState);
+}
+
+export async function setZoneBrightness(
+  zoneId: number,
+  brightness: number
 ): Promise<void> {
-  await Promise.all([
-    () => setRVLLightState(lightState),
-    () => setPhilipsHueLightState(lightState),
-    () => setLIFXLightState(lightState)
+  const zoneState = getItem(zoneId, systemState.zoneStates, 'zoneId');
+  if (zoneState.currentSceneId === undefined) {
+    return;
+  }
+  await setSceneBrightness(zoneState.currentSceneId, brightness);
+  setLightState(zoneState);
+}
+
+export async function setZonePower(
+  zoneId: number,
+  power: boolean
+): Promise<void> {
+  const zoneState = getItem(zoneId, systemState.zoneStates, 'zoneId');
+  zoneState.power = power;
+  setLightState(zoneState);
+}
+
+async function setLightState(zoneState: ZoneState): Promise<void> {
+  if (zoneState.currentSceneId === undefined) {
+    return;
+  }
+  const [scene, lights, patterns] = await Promise.all([
+    getItem(zoneState.currentSceneId, await getScenes()),
+    getLights(),
+    getPatterns()
+  ]);
+  const options: SetLightStateOptions = {
+    zoneState,
+    scene,
+    lights,
+    patterns
+  };
+  await Promise.allSettled([
+    setRVLLightState(options),
+    setPhilipsHueLightState(options),
+    setLIFXLightState(options)
   ]);
 }

--- a/server/src/device/phillipsHue.ts
+++ b/server/src/device/phillipsHue.ts
@@ -76,7 +76,9 @@ export async function setLightState({
     }
 
     let lightState: InstanceType<typeof LightState>;
-    if (lightEntry.patternId !== undefined) {
+    if (!zoneState.power) {
+      lightState = new LightState().off();
+    } else if (lightEntry.patternId !== undefined) {
       const pattern = getItem(lightEntry.patternId, patterns) as SolidPattern;
       if (pattern.type !== PatternType.Solid) {
         throw new Error(
@@ -102,6 +104,8 @@ export async function setLightState({
       authenticatedApi.lights.setLightState(
         idMap.get((light as PhilipsHueLight).philipsHueID),
         lightState
+        // The Hue API does strange things with types, gotta cast to any
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ) as any
     );
   }
@@ -109,6 +113,8 @@ export async function setLightState({
 }
 
 async function discoverBridge(): Promise<string | null> {
+  // The Hue API does strange things with types, gotta cast to any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let bridges: any;
   try {
     bridges = await philipsHue.discovery.nupnpSearch();

--- a/server/src/device/rvl.ts
+++ b/server/src/device/rvl.ts
@@ -66,7 +66,7 @@ export async function setLightState({
       controllers.set(light.channel, controller);
     }
 
-    if (lightEntry.patternId !== undefined) {
+    if (zoneState.power && lightEntry.patternId !== undefined) {
       controller.setPowerState(true);
       controller.setBrightness(scene.brightness);
       const pattern = getItem(lightEntry.patternId, patterns);

--- a/server/src/device/rvl.ts
+++ b/server/src/device/rvl.ts
@@ -17,15 +17,76 @@ You should have received a copy of the GNU General Public License
 along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { SetLightStateRequest } from '../common/types';
+import {
+  createManager,
+  createWaveParameters,
+  createSolidColorWave,
+  RVLManager,
+  RVLController
+} from 'rvl-node';
+import { MAX_BRIGHTNESS } from '../common/config';
+import {
+  LightType,
+  PatternType,
+  RVLLight,
+  SolidPattern
+} from '../common/types';
+import { getItem } from '../common/util';
+import { SetLightStateOptions } from './types';
+
+let manager: RVLManager;
+const controllers = new Map<number, RVLController>();
 
 export async function init(): Promise<void> {
+  manager = await createManager();
   // Devices are initialized on a per-channel basis, so we do nothing here
   console.log('RVL devices initialized');
 }
 
-export async function setLightState(
-  lightState: SetLightStateRequest
-): Promise<void> {
-  console.log(lightState);
+export async function setLightState({
+  zoneState,
+  scene,
+  lights,
+  patterns
+}: SetLightStateOptions): Promise<void> {
+  if (zoneState.currentSceneId === undefined) {
+    return;
+  }
+
+  for (const lightEntry of scene.lights) {
+    const light = getItem(lightEntry.lightId, lights) as RVLLight;
+    if (light.type !== LightType.RVL) {
+      continue;
+    }
+    let controller = controllers.get(light.channel);
+    if (!controller) {
+      controller = await manager.createController({
+        channel: light.channel
+      });
+      controllers.set(light.channel, controller);
+    }
+
+    if (lightEntry.patternId !== undefined) {
+      controller.setPowerState(true);
+      controller.setBrightness(scene.brightness);
+      const pattern = getItem(lightEntry.patternId, patterns);
+      switch (pattern.type) {
+        case PatternType.Solid: {
+          const { data } = pattern as SolidPattern;
+          controller.setWaveParameters(
+            createWaveParameters(
+              createSolidColorWave(
+                Math.round((data.color.hue / 360) * 255),
+                Math.round(data.color.saturation * 255),
+                Math.round((lightEntry.brightness / MAX_BRIGHTNESS) * 255)
+              )
+            )
+          );
+          break;
+        }
+      }
+    } else {
+      controller.setPowerState(false);
+    }
+  }
 }

--- a/server/src/device/types.ts
+++ b/server/src/device/types.ts
@@ -17,12 +17,11 @@ You should have received a copy of the GNU General Public License
 along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { FastifyInstance } from 'fastify';
-import { createScene, editScene, deleteScene } from '../db/scenes';
-import { post, put, del } from './endpoint';
+import { Light, Pattern, Scene, ZoneState } from '../common/types';
 
-export function init(app: FastifyInstance): void {
-  app.post('/api/scenes', post(createScene));
-  app.put('/api/scene/:id', put(editScene));
-  app.delete('/api/scene/:id', del(deleteScene));
+export interface SetLightStateOptions {
+  zoneState: ZoneState;
+  scene: Scene;
+  lights: Light[];
+  patterns: Pattern[];
 }

--- a/server/src/endpoints.ts
+++ b/server/src/endpoints.ts
@@ -23,6 +23,7 @@ import fastifyStatic from 'fastify-static';
 import { init as initLights } from './endpoints/lights';
 import { init as initPatterns } from './endpoints/patterns';
 import { init as initScenes } from './endpoints/scenes';
+import { init as initState } from './endpoints/state';
 import { init as initZones } from './endpoints/zones';
 import { getEnvironmentVariable } from './util';
 
@@ -39,6 +40,7 @@ export function init(): Promise<void> {
     initScenes(app);
     initPatterns(app);
     initLights(app);
+    initState(app);
 
     app.listen(port, (err, address) => {
       if (err) {

--- a/server/src/endpoints/endpoint.ts
+++ b/server/src/endpoints/endpoint.ts
@@ -1,0 +1,68 @@
+/*
+Copyright (c) Bryan Hughes <bryan@nebri.us>
+
+This file is part of Home Lights.
+
+Home Lights is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Home Lights is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { RouteHandlerMethod } from 'fastify';
+import { AppState } from '../common/types';
+import { getLights } from '../db/lights';
+import { getPatterns } from '../db/patterns';
+import { getScenes } from '../db/scenes';
+import { getZones } from '../db/zones';
+import { getSystemState } from '../device';
+import { reconcile } from '../reconcile';
+
+export function getAppState(): AppState {
+  return {
+    zones: getZones(),
+    scenes: getScenes(),
+    patterns: getPatterns(),
+    lights: getLights(),
+    systemState: getSystemState()
+  };
+}
+
+export function post<T>(
+  handler: (body: T) => Promise<void>
+): RouteHandlerMethod {
+  return async function (req) {
+    await handler.call(this, req.body as T);
+    await reconcile();
+    return getAppState();
+  };
+}
+
+export function put<T>(
+  handler: (body: T) => Promise<void>
+): RouteHandlerMethod {
+  return async function (req) {
+    await handler.call(this, req.body as T);
+    await reconcile();
+    return getAppState();
+  };
+}
+
+export function del(
+  handler: (id: number) => Promise<void>
+): RouteHandlerMethod {
+  return async function (req) {
+    const { id } = req.params as { id: string };
+    await handler.call(this, parseInt(id));
+    await reconcile();
+    return getAppState();
+  };
+}

--- a/server/src/endpoints/lights.ts
+++ b/server/src/endpoints/lights.ts
@@ -18,29 +18,11 @@ along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { FastifyInstance } from 'fastify';
-import { CreateLightRequest, Light } from '../common/types';
-import { getLights, createLight, editLight, deleteLight } from '../db/lights';
+import { createLight, editLight, deleteLight } from '../db/lights';
+import { post, put, del } from './endpoint';
 
 export function init(app: FastifyInstance): void {
-  app.get('/api/lights', async () => {
-    return await getLights();
-  });
-
-  app.post('/api/lights', async (req) => {
-    const lightRequest = req.body as CreateLightRequest;
-    await createLight(lightRequest);
-    return {};
-  });
-
-  app.put('/api/light/:id', async (req) => {
-    const light = req.body as Light;
-    await editLight(light);
-    return {};
-  });
-
-  app.delete('/api/light/:id', async (req) => {
-    const { id } = req.params as { id: string };
-    await deleteLight(parseInt(id));
-    return {};
-  });
+  app.post('/api/lights', post(createLight));
+  app.put('/api/light/:id', put(editLight));
+  app.delete('/api/light/:id', del(deleteLight));
 }

--- a/server/src/endpoints/patterns.ts
+++ b/server/src/endpoints/patterns.ts
@@ -18,34 +18,11 @@ along with Home Patterns.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { FastifyInstance } from 'fastify';
-import { Pattern, CreatePatternRequest } from '../common/types';
-import {
-  getPatterns,
-  createPattern,
-  editPattern,
-  deletePattern
-} from '../db/patterns';
+import { createPattern, editPattern, deletePattern } from '../db/patterns';
+import { post, put, del } from './endpoint';
 
 export function init(app: FastifyInstance): void {
-  app.get('/api/patterns', async () => {
-    return await getPatterns();
-  });
-
-  app.post('/api/patterns', async (req) => {
-    const patternRequest = req.body as CreatePatternRequest;
-    await createPattern(patternRequest);
-    return {};
-  });
-
-  app.put('/api/patterns/:id', async (req) => {
-    const pattern = req.body as Pattern;
-    await editPattern(pattern);
-    return {};
-  });
-
-  app.delete('/api/patterns/:id', async (req) => {
-    const { id } = req.params as { id: string };
-    await deletePattern(parseInt(id));
-    return {};
-  });
+  app.post('/api/patterns', post(createPattern));
+  app.put('/api/patterns/:id', put(editPattern));
+  app.delete('/api/patterns/:id', del(deletePattern));
 }

--- a/server/src/endpoints/state.ts
+++ b/server/src/endpoints/state.ts
@@ -1,0 +1,62 @@
+/*
+Copyright (c) Bryan Hughes <bryan@nebri.us>
+
+This file is part of Home Lights.
+
+Home Lights is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Home Lights is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { FastifyInstance } from 'fastify';
+import {
+  SetZoneSceneRequest,
+  SetZoneBrightnessRequest,
+  SetZonePowerRequest
+} from '../common/types';
+import {
+  getSystemState,
+  setZoneScene,
+  setZonePower,
+  setZoneBrightness
+} from '../device';
+import { getAppState, post } from './endpoint';
+
+export function init(app: FastifyInstance): void {
+  app.get('/api/app-state', async () => getAppState());
+
+  app.get('/api/states', async () => getSystemState());
+
+  app.post(
+    '/api/state-scene',
+    post(async (sceneRequest: SetZoneSceneRequest) => {
+      await setZoneScene(sceneRequest.sceneId);
+    })
+  );
+
+  app.post(
+    '/api/state-power',
+    post(async (powerRequest: SetZonePowerRequest) => {
+      await setZonePower(powerRequest.zoneId, powerRequest.power);
+    })
+  );
+
+  app.post(
+    '/api/state-brightness',
+    post(async (brightnessRequest: SetZoneBrightnessRequest) => {
+      await setZoneBrightness(
+        brightnessRequest.zoneId,
+        brightnessRequest.brightness
+      );
+    })
+  );
+}

--- a/server/src/endpoints/zones.ts
+++ b/server/src/endpoints/zones.ts
@@ -18,29 +18,11 @@ along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { FastifyInstance } from 'fastify';
-import { CreateZoneRequest, Zone } from '../common/types';
-import { getZones, createZone, editZone, deleteZone } from '../db/zones';
+import { createZone, editZone, deleteZone } from '../db/zones';
+import { post, put, del } from './endpoint';
 
 export function init(app: FastifyInstance): void {
-  app.get('/api/zones', async () => {
-    return await getZones();
-  });
-
-  app.post('/api/zones', async (req) => {
-    const zoneRequest = req.body as CreateZoneRequest;
-    await createZone(zoneRequest);
-    return {};
-  });
-
-  app.put('/api/zone/:id', async (req) => {
-    const zone = req.body as Zone;
-    await editZone(zone);
-    return {};
-  });
-
-  app.delete('/api/zone/:id', async (req) => {
-    const { id } = req.params as { id: string };
-    await deleteZone(parseInt(id));
-    return {};
-  });
+  app.post('/api/zones', post(createZone));
+  app.put('/api/zone/:id', put(editZone));
+  app.delete('/api/zone/:id', del(deleteZone));
 }

--- a/server/src/reconcile.ts
+++ b/server/src/reconcile.ts
@@ -17,16 +17,8 @@ You should have received a copy of the GNU General Public License
 along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { lightsReducer } from './lightsReducer';
-import { patternsReducer } from './patternsReducer';
-import { scenesReducer } from './scenesReducer';
-import { selectedTabReducer } from './selectedTabReducer';
-import { zonesReducer } from './zonesReducer';
+import { reconcile as reconcileDevice } from './device';
 
-export const reducers = [
-  zonesReducer,
-  scenesReducer,
-  patternsReducer,
-  lightsReducer,
-  selectedTabReducer
-];
+export function reconcile(): void {
+  reconcileDevice();
+}


### PR DESCRIPTION
This PR implements all of operations. Needs to be landed after #54, and probably rebased.

This PR also reworks a number of things pretty heavily:
- All POST/PUT/DELETE endpoints now return the complete app state to the user (zones, scenes, patterns, lights, and system state)
- All GET routes were removed
- A single GET route was created that returns the same thing as POST/PUT/DELETE endpoints, and is only used for app initialization
- Reducers were reworked to take in initial state fro the aforementioned GET route that is now called prior to the creation of reducers
- Endpoints were almost entirely rewritten, and make use of some helper methods that allowed endpoint code to be reduced to a single line
- A new reconciliation pattern was introduced after all CUD operations are completed that allows changes in one thing to cascade to other things (that can't be accomplished with an SQL cascade). This provides the mechanism needed for #62, #58, and #57 
- All of the get* methods in db files (getLights, etc.) now use a cached value so they can be synchronous. Now that all POST/PUT/DELETE endpoints return app state, these will be called a lot when nothing's changed
- As a result of the above, action listeners are now a lot simplier since they don't need to make separate calls to GET endpoints to update state

The combination of those changes above should mean that state updates are more reliable and performance should be better from reduced network calls and database reads.