### PR TITLE
Optimistic brightness

### DIFF
--- a/client/src/components/scene/createSceneButtonContainer.tsx
+++ b/client/src/components/scene/createSceneButtonContainer.tsx
@@ -41,7 +41,7 @@ export const CreateSceneButtonContainer = createContainer(
     ),
     patterns: getSlice(SliceName.Patterns),
     unavailableSceneNames: getSlice(SliceName.Scenes)
-      .filter((scene) => scene.zoneId === ownProps.zoneId)
+      .scenes.filter((scene) => scene.zoneId === ownProps.zoneId)
       .map((scene) => scene.name)
   }),
   (

--- a/client/src/components/scene/editSceneButtonContainer.tsx
+++ b/client/src/components/scene/editSceneButtonContainer.tsx
@@ -40,7 +40,7 @@ export const EditSceneButtonContainer = createContainer(
     patterns: getSlice(SliceName.Patterns),
     lights: getSlice(SliceName.Lights),
     unavailableSceneNames: getSlice(SliceName.Scenes)
-      .filter(
+      .scenes.filter(
         (scene) =>
           scene.zoneId === ownProps.scene.zoneId &&
           scene.id !== ownProps.scene.id

--- a/client/src/components/scene/zoneScenesContainer.tsx
+++ b/client/src/components/scene/zoneScenesContainer.tsx
@@ -42,7 +42,7 @@ export const ZoneScenesContainer = createContainer(
     );
     return {
       zone: ownProps.zone,
-      zoneScenes: getSlice(SliceName.Scenes).filter(
+      zoneScenes: getSlice(SliceName.Scenes).scenes.filter(
         (scene) => scene.zoneId === ownProps.zone.id
       ),
       zoneLights: [],

--- a/client/src/components/zone/zoneComponent.tsx
+++ b/client/src/components/zone/zoneComponent.tsx
@@ -50,7 +50,11 @@ export interface ZoneComponentProps {
 
 export type ZoneComponentDispatch = DeleteZoneButtonDispatch &
   ZonePowerSwitchDispatch & {
-    setZoneBrightness: (zoneId: number, brightness: number) => void;
+    setZoneBrightness: (
+      zoneId: number,
+      sceneId: number,
+      brightness: number
+    ) => void;
   };
 
 export const ZoneComponent: FunctionComponent<
@@ -100,7 +104,16 @@ export const ZoneComponent: FunctionComponent<
                       'Internal Error: expected number but got number[]'
                     );
                   }
-                  props.setZoneBrightness(props.zone.id, newValue);
+                  if (!props.currentScene) {
+                    throw new Error(
+                      'Internal Error: currentScene is undefined'
+                    );
+                  }
+                  props.setZoneBrightness(
+                    props.zone.id,
+                    props.currentScene.id,
+                    newValue
+                  );
                 }}
               />
             </div>

--- a/client/src/components/zone/zonesTab.tsx
+++ b/client/src/components/zone/zonesTab.tsx
@@ -24,7 +24,7 @@ import { EditMode, Scene, SystemState, Zone } from '../../common/types';
 import { getItem } from '../../common/util';
 import { useContainerStyles } from '../lib/pageStyles';
 import { CreateZoneButtonContainer } from './createZoneButtonContainer';
-import { ZoneComponent } from './zoneComponent';
+import { ZoneComponent, ZoneComponentDispatch } from './zoneComponent';
 
 export interface ZonesTabProps {
   zones: Zone[];
@@ -32,11 +32,7 @@ export interface ZonesTabProps {
   state: SystemState;
 }
 
-export interface ZonesTabDispatch {
-  deleteZone: (id: number) => void;
-  setZonePower: (id: number, powerState: boolean) => void;
-  setZoneBrightness: (id: number, brightness: number) => void;
-}
+export type ZonesTabDispatch = ZoneComponentDispatch;
 
 export const ZonesTab: FunctionComponent<ZonesTabProps & ZonesTabDispatch> = (
   props

--- a/client/src/components/zone/zonesTabContainer.tsx
+++ b/client/src/components/zone/zonesTabContainer.tsx
@@ -17,7 +17,6 @@ You should have received a copy of the GNU General Public License
 along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { debounce } from '@material-ui/core';
 import { ActionType } from '../../common/actions';
 import { createContainer } from '../../reduxology';
 import { SliceName } from '../../types';
@@ -27,7 +26,7 @@ export const ZonesTabContainer = createContainer(
   (getSlice): ZonesTabProps => ({
     zones: getSlice(SliceName.Zones),
     state: getSlice(SliceName.State),
-    scenes: getSlice(SliceName.Scenes)
+    scenes: getSlice(SliceName.Scenes).scenes
   }),
   (dispatch): ZonesTabDispatch => ({
     deleteZone(id) {
@@ -36,9 +35,9 @@ export const ZonesTabContainer = createContainer(
     setZonePower(zoneId, power) {
       dispatch(ActionType.SetZonePower, { zoneId, power });
     },
-    setZoneBrightness: debounce((zoneId, brightness) => {
-      dispatch(ActionType.SetZoneBrightness, { zoneId, brightness });
-    }, 33)
+    setZoneBrightness: (zoneId, sceneId, brightness) => {
+      dispatch(ActionType.SetZoneBrightness, { zoneId, sceneId, brightness });
+    }
   }),
   ZonesTab
 );

--- a/client/src/components/zone/zonesTabContainer.tsx
+++ b/client/src/components/zone/zonesTabContainer.tsx
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with Home Lights.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { debounce } from '@material-ui/core';
 import { ActionType } from '../../common/actions';
 import { createContainer } from '../../reduxology';
 import { SliceName } from '../../types';
@@ -35,9 +36,9 @@ export const ZonesTabContainer = createContainer(
     setZonePower(zoneId, power) {
       dispatch(ActionType.SetZonePower, { zoneId, power });
     },
-    setZoneBrightness: (zoneId, brightness) => {
+    setZoneBrightness: debounce((zoneId, brightness) => {
       dispatch(ActionType.SetZoneBrightness, { zoneId, brightness });
-    }
+    }, 33)
   }),
   ZonesTab
 );

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -38,7 +38,7 @@ async function run() {
     listeners,
     reducers: [
       createZonesReducers(appState.zones),
-      createScenesReducers(appState.scenes),
+      createScenesReducers(appState.scenes, appState.version),
       createPatternsReducers(appState.patterns),
       createLightsReducers(appState.lights),
       createStateReducers(appState.systemState),

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -40,7 +40,7 @@ export enum SliceName {
 
 export interface State {
   [SliceName.Zones]: Zone[];
-  [SliceName.Scenes]: Scene[];
+  [SliceName.Scenes]: { scenes: Scene[]; version: number };
   [SliceName.Lights]: Light[];
   [SliceName.Patterns]: Pattern[];
   [SliceName.State]: SystemState;

--- a/common/actions.ts
+++ b/common/actions.ts
@@ -66,7 +66,11 @@ export interface Actions {
 
   [ActionType.SetZoneScene]: { zoneId: number; sceneId: number };
   [ActionType.SetZonePower]: { zoneId: number; power: boolean };
-  [ActionType.SetZoneBrightness]: { zoneId: number; brightness: number };
+  [ActionType.SetZoneBrightness]: {
+    zoneId: number;
+    sceneId: number;
+    brightness: number;
+  };
 
   [ActionType.CreateZone]: Omit<Zone, 'id'>;
   [ActionType.EditZone]: Zone;

--- a/common/types.ts
+++ b/common/types.ts
@@ -25,6 +25,7 @@ export interface AppState {
   patterns: Pattern[];
   lights: Light[];
   systemState: SystemState;
+  version: number;
 }
 
 // ---- Zone Types ----


### PR DESCRIPTION
This PR implements optimistic brightness control. As part of this PR, I implemented some infrastructure stuff to make it easier. App state updates now includes a "version" that can be used by reducers to determine if they should update or not. This is used by optimistic updates that can artificially set the version to what the next one will be, which the reducers can then use to say "oh hey, I already did this update, I can skip it."

Fixes #68